### PR TITLE
원도우 엑셀 2007에서 한글이 깨지는 오류 수정. (euc-kr) 로 하면 깨지지 않음.

### DIFF
--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/CSVExpoter.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/CSVExpoter.java
@@ -84,22 +84,15 @@ public class CSVExpoter extends AbstractTDBExporter {
 	 * @param tableName
 	 * @param rsDAO
 	 * @param seprator
+	 * @param encoding
 	 * @return 파일 위치
 	 * 
 	 * @throws Exception
 	 */
-	public static String makeCSVFile(boolean isAddHead, String tableName, QueryExecuteResultDTO rsDAO, char seprator) throws Exception {
+	public static String makeCSVFile(boolean isAddHead, String tableName, QueryExecuteResultDTO rsDAO, char seprator, String encoding) throws Exception {
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".csv";
 		String strFullPath = strTmpDir + strFile;
-		
-		// add bom character
-//	    ByteArrayOutputStream out = new ByteArrayOutputStream();
-//	    //Add BOM characters
-//	    out.write(0xEF);
-//	    out.write(0xBB);
-//	    out.write(0xBF);
-//	    out.write(csvData.getBytes("UTF-8"));
 		
 		FileUtils.writeByteArrayToFile(new File(strFullPath), 
 						(new byte[] {(byte) 0xEF,
@@ -118,7 +111,7 @@ public class CSVExpoter extends AbstractTDBExporter {
 			}
 			listCsvData.add(strArrys);
 			String strTitle = CSVFileUtils.makeData(listCsvData, seprator);
-			FileUtils.writeStringToFile(new File(strFullPath), strTitle, true);
+			FileUtils.writeStringToFile(new File(strFullPath), strTitle, encoding, true);
 			
 			listCsvData.clear();
 		}
@@ -134,14 +127,14 @@ public class CSVExpoter extends AbstractTDBExporter {
 			listCsvData.add(strArrys);
 			
 			if((i%DATA_COUNT) == 0) {
-				FileUtils.writeStringToFile(new File(strFullPath), CSVFileUtils.makeData(listCsvData, seprator), true);
+				FileUtils.writeStringToFile(new File(strFullPath), CSVFileUtils.makeData(listCsvData, seprator), encoding, true);
 				listCsvData.clear();
 			}
 		}
 		
 		// 컬럼 이름.
 		if(!listCsvData.isEmpty()) {
-			FileUtils.writeStringToFile(new File(strFullPath), CSVFileUtils.makeData(listCsvData, seprator), true);
+			FileUtils.writeStringToFile(new File(strFullPath), CSVFileUtils.makeData(listCsvData, seprator), encoding, true);
 		}
 		
 		return strFullPath;

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/HTMLExporter.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/HTMLExporter.java
@@ -76,17 +76,18 @@ public class HTMLExporter extends AbstractTDBExporter {
 	 * 
 	 * @param tableName
 	 * @param rsDAO
+	 * @param encoding 
 	 * @return
 	 * @throws Exception
 	 */
-	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO) throws Exception {
+	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO, String encoding) throws Exception {
 		// full text
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".html";
 		String strFullPath = strTmpDir + strFile;
 		
-		FileUtils.writeStringToFile(new File(strFullPath), HTMLDefine.HTML_STYLE, true);
-		FileUtils.writeStringToFile(new File(strFullPath), "<table class='tg'>", true);
+		FileUtils.writeStringToFile(new File(strFullPath), HTMLDefine.HTML_STYLE, encoding, true);
+		FileUtils.writeStringToFile(new File(strFullPath), "<table class='tg'>", encoding, true);
 		
 		// make content
 		List<Map<Integer, Object>> dataList = rsDAO.getDataList().getData();
@@ -100,7 +101,7 @@ public class HTMLExporter extends AbstractTDBExporter {
 		String strLastColumnName = HTMLDefine.makeTR(sbHead.toString());
 		
 		// header
-		FileUtils.writeStringToFile(new File(strFullPath), strLastColumnName, true);
+		FileUtils.writeStringToFile(new File(strFullPath), strLastColumnName, encoding, true);
 		
 		// body start
 		StringBuffer sbBody = new StringBuffer("");
@@ -116,15 +117,15 @@ public class HTMLExporter extends AbstractTDBExporter {
 			sbBody.append(HTMLDefine.makeTR(sbTmp.toString()));
 			
 			if((i%DATA_COUNT) == 0) {
-				FileUtils.writeStringToFile(new File(strFullPath), sbBody.toString(), true);
+				FileUtils.writeStringToFile(new File(strFullPath), sbBody.toString(), encoding, true);
 				sbBody.delete(0, sbBody.length());
 			}
 		}
 		
 		if(sbBody.length() > 0) {
-			FileUtils.writeStringToFile(new File(strFullPath), sbBody.toString(), true);
+			FileUtils.writeStringToFile(new File(strFullPath), sbBody.toString(), encoding, true);
 		}
-		FileUtils.writeStringToFile(new File(strFullPath), "</table>", true);
+		FileUtils.writeStringToFile(new File(strFullPath), "</table>", encoding, true);
 		
 		return strFullPath;
 	}

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/JsonExpoter.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/JsonExpoter.java
@@ -125,30 +125,30 @@ public class JsonExpoter extends AbstractTDBExporter {
 	 * @return
 	 * @throws Exception
 	 */
-	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO) throws Exception {
-		return makeContentFile(tableName, rsDAO, true); 
+	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO, String encoding) throws Exception {
+		return makeContentFile(tableName, rsDAO, true, encoding); 
 	}
 	
-	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO, boolean isFormat) throws Exception {
+	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO, boolean isFormat, String encoding) throws Exception {
 		String strContent = makeContent(tableName, rsDAO, isFormat, -1);
 		
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".json";
 		String strFullPath = strTmpDir + strFile;
 		
-		FileUtils.writeStringToFile(new File(strFullPath), strContent, true);
+		FileUtils.writeStringToFile(new File(strFullPath), strContent, encoding, true);
 		
 		return strFullPath;
 	}
 	
-	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO, String schemeKey, String recordKey, boolean isFormat) throws Exception {
+	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO, String schemeKey, String recordKey, boolean isFormat, String encoding) throws Exception {
 		String strContent = makeContent(tableName, rsDAO, schemeKey, recordKey, isFormat, -1);
 		
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".json";
 		String strFullPath = strTmpDir + strFile;
 		
-		FileUtils.writeStringToFile(new File(strFullPath), strContent, true);
+		FileUtils.writeStringToFile(new File(strFullPath), strContent, encoding, true);
 		
 		return strFullPath;
 	}

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/SQLExporter.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/SQLExporter.java
@@ -106,7 +106,7 @@ public class SQLExporter extends AbstractTDBExporter {
 		return sbInsertInto.toString();
 	}
 	
-	public static String makeFileMergeStatment(String tableName, QueryExecuteResultDTO rsDAO, List<String> listWhere, int commit) throws Exception {
+	public static String makeFileMergeStatment(String tableName, QueryExecuteResultDTO rsDAO, List<String> listWhere, int commit, String encoding) throws Exception {
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".sql";
 		String strFullPath = strTmpDir + strFile;
@@ -171,7 +171,7 @@ public class SQLExporter extends AbstractTDBExporter {
 			} 
 
 			if((i%DATA_COUNT) == 0) {
-				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 				sbInsertInto.setLength(0);
 			}
 		}
@@ -180,7 +180,7 @@ public class SQLExporter extends AbstractTDBExporter {
 				sbInsertInto.append("COMMIT" + PublicTadpoleDefine.SQL_DELIMITER + PublicTadpoleDefine.LINE_SEPARATOR);
 			} 
 
-			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 		}
 		
 		return strFullPath;
@@ -245,7 +245,7 @@ public class SQLExporter extends AbstractTDBExporter {
 		return sbInsertInto.toString();
 	}
 
-	public static String makeFileUpdateStatment(String tableName, QueryExecuteResultDTO rsDAO, List<String> listWhere, int commit) throws Exception {
+	public static String makeFileUpdateStatment(String tableName, QueryExecuteResultDTO rsDAO, List<String> listWhere, int commit, String encoding) throws Exception {
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".sql";
 		String strFullPath = strTmpDir + strFile;
@@ -295,7 +295,7 @@ public class SQLExporter extends AbstractTDBExporter {
 			} 
 
 			if((i%DATA_COUNT) == 0) {
-				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 				sbInsertInto.setLength(0);
 			}
 		}
@@ -304,7 +304,7 @@ public class SQLExporter extends AbstractTDBExporter {
 				sbInsertInto.append("COMMIT" + PublicTadpoleDefine.SQL_DELIMITER + PublicTadpoleDefine.LINE_SEPARATOR);
 			} 
 
-			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 		}
 		
 		return strFullPath;
@@ -364,7 +364,7 @@ public class SQLExporter extends AbstractTDBExporter {
 		return sbInsertInto.toString();
 	}
 	
-	public static String makeFileInsertStatment(String tableName, QueryExecuteResultDTO rsDAO, int commit) throws Exception {
+	public static String makeFileInsertStatment(String tableName, QueryExecuteResultDTO rsDAO, int commit, String encoding) throws Exception {
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".sql";
 		String strFullPath = strTmpDir + strFile;
@@ -409,7 +409,7 @@ public class SQLExporter extends AbstractTDBExporter {
 			} 
 
 			if((i%DATA_COUNT) == 0) {
-				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 				sbInsertInto.setLength(0);
 			}
 		}
@@ -418,7 +418,7 @@ public class SQLExporter extends AbstractTDBExporter {
 				sbInsertInto.append("COMMIT" + PublicTadpoleDefine.SQL_DELIMITER + PublicTadpoleDefine.LINE_SEPARATOR);
 			} 
 
-			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 		}
 		
 		return strFullPath;
@@ -494,7 +494,7 @@ public class SQLExporter extends AbstractTDBExporter {
 		return sbInsertInto.toString();
 	}
 	
-	public static String makeFileBatchInsertStatment(String tableName, QueryExecuteResultDTO rsDAO, int commit) throws Exception {
+	public static String makeFileBatchInsertStatment(String tableName, QueryExecuteResultDTO rsDAO, int commit, String encoding) throws Exception {
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".sql";
 		String strFullPath = strTmpDir + strFile;
@@ -551,7 +551,7 @@ public class SQLExporter extends AbstractTDBExporter {
 					sbInsertInto.append("COMMIT" + PublicTadpoleDefine.SQL_DELIMITER + PublicTadpoleDefine.LINE_SEPARATOR);
 				} 
 
-				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+				FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 				sbInsertInto.setLength(0);
 			}
 			
@@ -564,7 +564,7 @@ public class SQLExporter extends AbstractTDBExporter {
 				sbInsertInto.append("COMMIT" + PublicTadpoleDefine.SQL_DELIMITER + PublicTadpoleDefine.LINE_SEPARATOR);
 			} 
 			
-			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), true);
+			FileUtils.writeStringToFile(new File(strFullPath), sbInsertInto.toString(), encoding, true);
 		}
 		
 		return strFullPath;

--- a/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/XMLExporter.java
+++ b/com.hangum.tadpole.commons.sql/src/com/hangum/tadpole/engine/sql/util/export/XMLExporter.java
@@ -106,10 +106,11 @@ public class XMLExporter extends AbstractTDBExporter {
 	 * 
 	 * @param tableName
 	 * @param rsDAO
+	 * @param encoding 
 	 * @return
 	 * @throws Exception
 	 */
-	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO) throws Exception {
+	public static String makeContentFile(String tableName, QueryExecuteResultDTO rsDAO, String encoding) throws Exception {
 		String strTmpDir = PublicTadpoleDefine.TEMP_DIR + tableName + System.currentTimeMillis() + PublicTadpoleDefine.DIR_SEPARATOR;
 		String strFile = tableName + ".xml";
 		String strFullPath = strTmpDir + strFile;
@@ -152,7 +153,7 @@ public class XMLExporter extends AbstractTDBExporter {
 		StreamResult sr = new StreamResult(stWriter);
 		transformer.transform(domSource, sr);
 		
-		FileUtils.writeStringToFile(new File(strFullPath), stWriter.toString(), true);
+		FileUtils.writeStringToFile(new File(strFullPath), stWriter.toString(), encoding, true);
 		
 		return strFullPath;
 	}

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/ResultSetDownloadDialog.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/ResultSetDownloadDialog.java
@@ -332,7 +332,7 @@ public class ResultSetDownloadDialog extends Dialog {
 			targetEditor(CSVExpoter.makeContent(isAddHead, targetName, queryExecuteResultDTO, seprator));
 		}else{
 			QueryExecuteResultDTO allResusltDto = makeAllResult();
-			downloadFile(targetName, CSVExpoter.makeCSVFile(isAddHead, targetName, allResusltDto, seprator), encoding);
+			downloadFile(targetName, CSVExpoter.makeCSVFile(isAddHead, targetName, allResusltDto, seprator, encoding), encoding);
 		}
 	}
 	
@@ -349,7 +349,7 @@ public class ResultSetDownloadDialog extends Dialog {
 			targetEditor(HTMLExporter.makeContent(targetName, queryExecuteResultDTO));
 		}else{
 			QueryExecuteResultDTO allResusltDto = makeAllResult();
-			downloadFile(targetName, HTMLExporter.makeContentFile(targetName, allResusltDto), encoding);
+			downloadFile(targetName, HTMLExporter.makeContentFile(targetName, allResusltDto, encoding), encoding);
 		}
 	}
 	
@@ -371,7 +371,7 @@ public class ResultSetDownloadDialog extends Dialog {
 				targetEditor(JsonExpoter.makeContent(targetName, queryExecuteResultDTO, schemeKey, recordKey, isFormat, -1));
 			}else{
 				QueryExecuteResultDTO allResusltDto = makeAllResult();
-				downloadFile(targetName, JsonExpoter.makeContentFile(targetName, allResusltDto, schemeKey, recordKey, isFormat), encoding);
+				downloadFile(targetName, JsonExpoter.makeContentFile(targetName, allResusltDto, schemeKey, recordKey, isFormat, encoding), encoding);
 			}
 		}else{
 			if (btnStatus == BTN_STATUS.PREVIEW) {
@@ -380,7 +380,7 @@ public class ResultSetDownloadDialog extends Dialog {
 				targetEditor(JsonExpoter.makeContent(targetName, queryExecuteResultDTO, isFormat, -1));
 			}else{
 				QueryExecuteResultDTO allResusltDto = makeAllResult();
-				downloadFile(targetName, JsonExpoter.makeContentFile(targetName, allResusltDto, isFormat), encoding);
+				downloadFile(targetName, JsonExpoter.makeContentFile(targetName, allResusltDto, isFormat, encoding), encoding);
 			}
 		}
 	}
@@ -398,7 +398,7 @@ public class ResultSetDownloadDialog extends Dialog {
 			targetEditor(XMLExporter.makeContent(targetName, queryExecuteResultDTO));
 		}else{
 			QueryExecuteResultDTO allResusltDto = makeAllResult();
-			downloadFile(targetName, XMLExporter.makeContentFile(targetName, allResusltDto), encoding);
+			downloadFile(targetName, XMLExporter.makeContentFile(targetName, allResusltDto, encoding), encoding);
 		}
 	}
 	
@@ -419,7 +419,7 @@ public class ResultSetDownloadDialog extends Dialog {
 				targetEditor(SQLExporter.makeBatchInsertStatment(targetName, queryExecuteResultDTO, -1, commit));
 			}else{
 				QueryExecuteResultDTO allResusltDto = makeAllResult();
-				downloadFile(targetName, SQLExporter.makeFileBatchInsertStatment(targetName, allResusltDto, commit), encoding);
+				downloadFile(targetName, SQLExporter.makeFileBatchInsertStatment(targetName, allResusltDto, commit, encoding), encoding);
 			}
 		}else if ("insert".equalsIgnoreCase(stmtType)) {
 			if (btnStatus == BTN_STATUS.PREVIEW) {
@@ -428,7 +428,7 @@ public class ResultSetDownloadDialog extends Dialog {
 				targetEditor(SQLExporter.makeInsertStatment(targetName, queryExecuteResultDTO, -1, commit));
 			}else{
 				QueryExecuteResultDTO allResusltDto = makeAllResult();
-				downloadFile(targetName, SQLExporter.makeFileInsertStatment(targetName, allResusltDto, commit), encoding);
+				downloadFile(targetName, SQLExporter.makeFileInsertStatment(targetName, allResusltDto, commit, encoding), encoding);
 			}
 		}else if ("update".equalsIgnoreCase(stmtType)) {
 			if (btnStatus == BTN_STATUS.PREVIEW) {
@@ -437,7 +437,7 @@ public class ResultSetDownloadDialog extends Dialog {
 				targetEditor(SQLExporter.makeUpdateStatment(targetName, queryExecuteResultDTO, listWhere, -1, commit));
 			}else{
 				QueryExecuteResultDTO allResusltDto = makeAllResult();
-				downloadFile(targetName, SQLExporter.makeFileUpdateStatment(targetName, allResusltDto, listWhere, commit), encoding);
+				downloadFile(targetName, SQLExporter.makeFileUpdateStatment(targetName, allResusltDto, listWhere, commit, encoding), encoding);
 			}
 		}else if ("merge".equalsIgnoreCase(stmtType)) {
 			if (btnStatus == BTN_STATUS.PREVIEW) {
@@ -446,7 +446,7 @@ public class ResultSetDownloadDialog extends Dialog {
 				targetEditor(SQLExporter.makeMergeStatment(targetName, queryExecuteResultDTO, listWhere, -1, commit));
 			}else{
 				QueryExecuteResultDTO allResusltDto = makeAllResult();
-				downloadFile(targetName, SQLExporter.makeFileMergeStatment(targetName, allResusltDto, listWhere, commit), encoding);
+				downloadFile(targetName, SQLExporter.makeFileMergeStatment(targetName, allResusltDto, listWhere, commit, encoding), encoding);
 			}
 		}
 	}

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportHTMLComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportHTMLComposite.java
@@ -65,7 +65,9 @@ public class ExportHTMLComposite extends AbstractExportComposite {
 		
 		comboEncoding = new Combo(compositeText, SWT.NONE);
 		comboEncoding.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		comboEncoding.setText("UTF-8");
+		comboEncoding.add("UTF-8");
+		comboEncoding.add("euc-kr");
+		comboEncoding.select(0);
 	}
 
 	@Override

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportJSONComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportJSONComposite.java
@@ -134,9 +134,12 @@ public class ExportJSONComposite extends AbstractExportComposite {
 		
 		textTargetName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		textTargetName.setText(defaultTargetName);
+		
 		comboEncoding.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		comboEncoding.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		comboEncoding.setText("UTF-8");
+		comboEncoding.add("UTF-8");
+		comboEncoding.add("euc-kr");
+		comboEncoding.select(0);
 	}
 
 	@Override

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportSQLComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportSQLComposite.java
@@ -135,7 +135,10 @@ public class ExportSQLComposite extends AbstractExportComposite {
 		
 		comboEncoding = new Combo(compositeText, SWT.NONE);
 		comboEncoding.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		comboEncoding.setText("UTF-8");
+		comboEncoding.add("UTF-8");
+		comboEncoding.add("euc-kr");
+		comboEncoding.select(0);
+		
 		new Label(compositeText, SWT.NONE);
 		
 		grpWhere = new Group(compositeText, SWT.NONE);

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportTextComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportTextComposite.java
@@ -114,7 +114,9 @@ public class ExportTextComposite extends AbstractExportComposite {
 		
 		comboEncoding = new Combo(compositeText, SWT.NONE);
 		comboEncoding.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		comboEncoding.setText("UTF-8");
+		comboEncoding.add("UTF-8");
+		comboEncoding.add("euc-kr");
+		comboEncoding.select(0);
 	}
 
 	@Override

--- a/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportXMLComposite.java
+++ b/com.hangum.tadpole.rdb.core/src/com/hangum/tadpole/rdb/core/dialog/export/sqlresult/composite/ExportXMLComposite.java
@@ -65,7 +65,9 @@ public class ExportXMLComposite extends AbstractExportComposite {
 		
 		comboEncoding = new Combo(compositeText, SWT.NONE);
 		comboEncoding.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		comboEncoding.setText("UTF-8");
+		comboEncoding.add("UTF-8");
+		comboEncoding.add("euc-kr");
+		comboEncoding.select(0);
 	}
 
 	@Override


### PR DESCRIPTION
맥 최신 버전, 엑셀 2010에서는 깨지지 않음.
